### PR TITLE
fix registries input name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ branding:
   icon: 'cloud'
   color: 'orange'
 inputs:
-  registry-ids:
+  registries:
     description: 'A comma-delimited list of AWS account IDs that are associated with the ECR registries. If you do not specify a registry, the default ECR registry is assumed.'
     required: false
 outputs:


### PR DESCRIPTION
The input name was wrong, as seen here:
https://github.com/aws-actions/amazon-ecr-login/blob/dd8d21e30b2ebd160d156a405af038369ea9a33e/index.js#L7

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
