### PR TITLE
feat: logout docker registries in post step

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ Logs in the local Docker client to one or more Amazon ECR registries.
       run: |
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-
-    - name: Logout of Amazon ECR
-      if: always()
-      run: docker logout ${{ steps.login-ecr.outputs.registry }}
 ```
 
 See [action.yml](action.yml) for the full documentation for this action's inputs and outputs.

--- a/action.yml
+++ b/action.yml
@@ -13,3 +13,4 @@ outputs:
 runs:
   using: 'node12'
   main: 'dist/index.js'
+  post: 'dist/cleanup/index.js'

--- a/cleanup.js
+++ b/cleanup.js
@@ -1,0 +1,51 @@
+const core = require('@actions/core');
+const exec = require('@actions/exec');
+
+/**
+ * When the GitHub Actions job is done, remove saved ECR credentials from the
+ * local Docker engine in the job's environment.
+ */
+
+async function cleanup() {
+ try {
+    const registriesState = core.getState('registries');
+    if (registriesState) {
+      const registries = registriesState.split(',');
+
+      for (const registry of registries) {
+        core.debug(`Logging out registry ${registry}`);
+
+        // Execute the docker logout command
+        let doLogoutStdout = '';
+        let doLogoutStderr = '';
+        const exitCode = await exec.exec('docker logout', [registry], {
+          silent: true,
+          ignoreReturnCode: true,
+          listeners: {
+            stdout: (data) => {
+              doLogoutStdout += data.toString();
+            },
+            stderr: (data) => {
+              doLogoutStderr += data.toString();
+            }
+          }
+        });
+
+        if (exitCode != 0) {
+          core.debug(doLogoutStdout);
+          throw new Error('Could not logout: ' + doLogoutStderr);
+        }
+      }
+    }
+  }
+  catch (error) {
+    core.setFailed(error.message);
+  }
+}
+
+module.exports = cleanup;
+
+/* istanbul ignore next */
+if (require.main === module) {
+  cleanup();
+}

--- a/cleanup.js
+++ b/cleanup.js
@@ -11,6 +11,7 @@ async function cleanup() {
     const registriesState = core.getState('registries');
     if (registriesState) {
       const registries = registriesState.split(',');
+      const failedLogouts = [];
 
       for (const registry of registries) {
         core.debug(`Logging out registry ${registry}`);
@@ -33,8 +34,13 @@ async function cleanup() {
 
         if (exitCode != 0) {
           core.debug(doLogoutStdout);
-          throw new Error('Could not logout: ' + doLogoutStderr);
+          core.error(`Could not logout registry ${registry}: ${doLogoutStderr}`);
+          failedLogouts.push(registry);
         }
+      }
+
+      if (failedLogouts.length) {
+        throw new Error(`Failed to logout: ${failedLogouts.join(',')}`);
       }
     }
   }

--- a/cleanup.test.js
+++ b/cleanup.test.js
@@ -1,0 +1,54 @@
+const cleanup = require('./cleanup.js');
+const core = require('@actions/core');
+const exec = require('@actions/exec');
+
+jest.mock('@actions/core');
+jest.mock('@actions/exec');
+
+describe('Logout from ECR', () => {
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        core.getState.mockReturnValue(
+            '123456789012.dkr.ecr.aws-region-1.amazonaws.com,111111111111.dkr.ecr.aws-region-1.amazonaws.com');
+        exec.exec.mockReturnValue(0);
+    });
+
+    test('logs out docker client for registries in action state', async () => {
+        await cleanup();
+
+        expect(core.getState).toHaveBeenCalledWith('registries');
+
+        expect(exec.exec).toHaveBeenCalledTimes(2);
+        expect(exec.exec).toHaveBeenNthCalledWith(1,
+            'docker logout',
+            ['123456789012.dkr.ecr.aws-region-1.amazonaws.com'],
+            expect.anything());
+        expect(exec.exec).toHaveBeenNthCalledWith(2,
+            'docker logout',
+            ['111111111111.dkr.ecr.aws-region-1.amazonaws.com'],
+            expect.anything());
+
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
+    });
+
+    test('handles zero registries', async () => {
+        core.getState.mockReturnValue('');
+
+        await cleanup();
+
+        expect(core.getState).toHaveBeenCalledWith('registries');
+
+        expect(exec.exec).toHaveBeenCalledTimes(0);
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
+    });
+
+    test('error is caught by core.setFailed for failed docker logout', async () => {
+        exec.exec.mockReturnValue(1);
+
+        await cleanup();
+
+        expect(core.setFailed).toBeCalled();
+    });
+});

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint **.js",
-    "package": "ncc build index.js -o dist",
-    "test": "eslint **.js && jest --coverage"
+    "package": "ncc build index.js -o dist && ncc build cleanup.js -o dist/cleanup",
+    "test": "eslint **.js && jest --coverage --verbose"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
In the post-job cleanup, do a `docker logout` for all registries that had a successful `docker login` via this action.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
