### PR TITLE
fix: add-mask to login outputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,8 @@ async function run() {
       }
 
       const secretSuffix = replaceSpecialCharacters(registryUri)
+      core.setSecret(creds[0])
+      core.setSecret(creds[1])
       core.setOutput(`docker_username_${secretSuffix}`, creds[0]);
       core.setOutput(`docker_password_${secretSuffix}`, creds[1]);
 

--- a/index.test.js
+++ b/index.test.js
@@ -292,6 +292,10 @@ describe('Login to ECR', () => {
         });
 
         await run();
+        expect(core.setSecret).toHaveBeenNthCalledWith(1, 'hello');
+        expect(core.setSecret).toHaveBeenNthCalledWith(2, 'world');
+        expect(core.setSecret).toHaveBeenNthCalledWith(3, 'foo');
+        expect(core.setSecret).toHaveBeenNthCalledWith(4, 'bar');
         expect(core.setOutput).toHaveBeenNthCalledWith(1, 'docker_username_123456789012_dkr_ecr_aws_region_1_amazonaws_com', 'hello');
         expect(core.setOutput).toHaveBeenNthCalledWith(2, 'docker_password_123456789012_dkr_ecr_aws_region_1_amazonaws_com', 'world');
         expect(core.setOutput).toHaveBeenNthCalledWith(3, 'docker_username_111111111111_dkr_ecr_aws_region_1_amazonaws_com', 'foo');


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

*Description of changes:*
Registry passwords are being echo'ed to the console and should be masked.
This feature was initially added as part of - https://github.com/aws-actions/amazon-ecr-login/pull/191/files
But a subsequent PR removed the mask functionality - https://github.com/aws-actions/amazon-ecr-login/pull/214

See definition - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-log
See alternate implementation - https://github.com/aws-actions/configure-aws-credentials/search?q=setSecret

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
