### PR TITLE
refactor: Differentiate between cmd and args

### DIFF
--- a/cleanup.js
+++ b/cleanup.js
@@ -19,7 +19,7 @@ async function cleanup() {
         // Execute the docker logout command
         let doLogoutStdout = '';
         let doLogoutStderr = '';
-        const exitCode = await exec.exec('docker logout', [registry], {
+        const exitCode = await exec.exec('docker', ["logout", registry], {
           silent: true,
           ignoreReturnCode: true,
           listeners: {

--- a/cleanup.test.js
+++ b/cleanup.test.js
@@ -22,12 +22,12 @@ describe('Logout from ECR', () => {
 
         expect(exec.exec).toHaveBeenCalledTimes(2);
         expect(exec.exec).toHaveBeenNthCalledWith(1,
-            'docker logout',
-            ['123456789012.dkr.ecr.aws-region-1.amazonaws.com'],
+            'docker',
+            ['logout', '123456789012.dkr.ecr.aws-region-1.amazonaws.com'],
             expect.anything());
         expect(exec.exec).toHaveBeenNthCalledWith(2,
-            'docker logout',
-            ['111111111111.dkr.ecr.aws-region-1.amazonaws.com'],
+            'docker',
+            ['logout', '111111111111.dkr.ecr.aws-region-1.amazonaws.com'],
             expect.anything());
 
         expect(core.setFailed).toHaveBeenCalledTimes(0);
@@ -63,16 +63,16 @@ describe('Logout from ECR', () => {
 
         expect(exec.exec).toHaveBeenCalledTimes(3);
         expect(exec.exec).toHaveBeenNthCalledWith(1,
-            'docker logout',
-            ['123456789012.dkr.ecr.aws-region-1.amazonaws.com'],
+            'docker',
+            ['logout', '123456789012.dkr.ecr.aws-region-1.amazonaws.com'],
             expect.anything());
         expect(exec.exec).toHaveBeenNthCalledWith(2,
-            'docker logout',
-            ['111111111111.dkr.ecr.aws-region-1.amazonaws.com'],
+            'docker',
+            ['logout', '111111111111.dkr.ecr.aws-region-1.amazonaws.com'],
             expect.anything());
         expect(exec.exec).toHaveBeenNthCalledWith(3,
-            'docker logout',
-            ['222222222222.dkr.ecr.aws-region-1.amazonaws.com'],
+            'docker',
+            ['logout', '222222222222.dkr.ecr.aws-region-1.amazonaws.com'],
             expect.anything());
 
         expect(core.error).toHaveBeenCalledTimes(2);

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ async function run() {
       authTokenRequest.registryIds = registryIds;
     }
     const authTokenResponse = await ecr.getAuthorizationToken(authTokenRequest).promise();
-    if (!Array.isArray(authTokenResponse.authorizationData) || !authTokenResponse.authorizationData.length) {
+    if (!authTokenResponse || !Array.isArray(authTokenResponse.authorizationData) || !authTokenResponse.authorizationData.length) {
       throw new Error('Could not retrieve an authorization token from Amazon ECR');
     }
 

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ async function run() {
       // Execute the docker login command
       let doLoginStdout = '';
       let doLoginStderr = '';
-      const exitCode = await exec.exec('docker login', ['-u', creds[0], '-p', creds[1], proxyEndpoint], {
+      const exitCode = await exec.exec('docker', ['login', '-u', creds[0], '-p', creds[1], proxyEndpoint], {
         silent: true,
         ignoreReturnCode: true,
         listeners: {

--- a/index.test.js
+++ b/index.test.js
@@ -57,8 +57,8 @@ describe('Login to ECR', () => {
         expect(mockEcrGetAuthToken).toHaveBeenCalled();
         expect(core.setOutput).toHaveBeenNthCalledWith(1, 'registry', '123456789012.dkr.ecr.aws-region-1.amazonaws.com');
         expect(exec.exec).toHaveBeenNthCalledWith(1,
-            'docker login',
-            ['-u', 'hello', '-p', 'world', 'https://123456789012.dkr.ecr.aws-region-1.amazonaws.com'],
+            'docker',
+            ['login', '-u', 'hello', '-p', 'world', 'https://123456789012.dkr.ecr.aws-region-1.amazonaws.com'],
             expect.anything());
         expect(core.saveState).toHaveBeenCalledTimes(1);
         expect(core.saveState).toHaveBeenCalledWith('registries', '123456789012.dkr.ecr.aws-region-1.amazonaws.com');
@@ -96,12 +96,12 @@ describe('Login to ECR', () => {
         expect(core.setOutput).toHaveBeenCalledTimes(4);
         expect(exec.exec).toHaveBeenCalledTimes(2);
         expect(exec.exec).toHaveBeenNthCalledWith(1,
-            'docker login',
-            ['-u', 'hello', '-p', 'world', 'https://123456789012.dkr.ecr.aws-region-1.amazonaws.com'],
+            'docker',
+            ['login', '-u', 'hello', '-p', 'world', 'https://123456789012.dkr.ecr.aws-region-1.amazonaws.com'],
             expect.anything());
         expect(exec.exec).toHaveBeenNthCalledWith(2,
-            'docker login',
-            ['-u', 'foo', '-p', 'bar', 'https://111111111111.dkr.ecr.aws-region-1.amazonaws.com'],
+            'docker',
+            ['login', '-u', 'foo', '-p', 'bar', 'https://111111111111.dkr.ecr.aws-region-1.amazonaws.com'],
             expect.anything());
         expect(core.saveState).toHaveBeenCalledTimes(1);
         expect(core.saveState).toHaveBeenCalledWith('registries', '123456789012.dkr.ecr.aws-region-1.amazonaws.com,111111111111.dkr.ecr.aws-region-1.amazonaws.com');
@@ -136,8 +136,8 @@ describe('Login to ECR', () => {
         expect(core.setOutput).toHaveBeenNthCalledWith(1, 'registry', '111111111111.dkr.ecr.aws-region-1.amazonaws.com');
         expect(exec.exec).toHaveBeenCalledTimes(1);
         expect(exec.exec).toHaveBeenNthCalledWith(1,
-            'docker login',
-            ['-u', 'foo', '-p', 'bar', 'https://111111111111.dkr.ecr.aws-region-1.amazonaws.com'],
+            'docker',
+            ['login', '-u', 'foo', '-p', 'bar', 'https://111111111111.dkr.ecr.aws-region-1.amazonaws.com'],
             expect.anything());
         expect(core.saveState).toHaveBeenCalledTimes(1);
         expect(core.saveState).toHaveBeenCalledWith('registries', '111111111111.dkr.ecr.aws-region-1.amazonaws.com');
@@ -187,12 +187,12 @@ describe('Login to ECR', () => {
         expect(core.setOutput).toHaveBeenCalledTimes(2);
         expect(exec.exec).toHaveBeenCalledTimes(2);
         expect(exec.exec).toHaveBeenNthCalledWith(1,
-            'docker login',
-            ['-u', 'hello', '-p', 'world', 'https://123456789012.dkr.ecr.aws-region-1.amazonaws.com'],
+            'docker',
+            ['login', '-u', 'hello', '-p', 'world', 'https://123456789012.dkr.ecr.aws-region-1.amazonaws.com'],
             expect.anything());
         expect(exec.exec).toHaveBeenNthCalledWith(2,
-            'docker login',
-            ['-u', 'foo', '-p', 'bar', 'https://111111111111.dkr.ecr.aws-region-1.amazonaws.com'],
+            'docker',
+            ['login', '-u', 'foo', '-p', 'bar', 'https://111111111111.dkr.ecr.aws-region-1.amazonaws.com'],
             expect.anything());
 
         expect(core.setFailed).toBeCalled();
@@ -222,8 +222,8 @@ describe('Login to ECR', () => {
         expect(mockEcrGetAuthToken).toHaveBeenCalled();
         expect(core.setOutput).toHaveBeenNthCalledWith(1, 'registry', '123456789012.dkr.ecr.aws-region-1.amazonaws.com');
         expect(exec.exec).toHaveBeenNthCalledWith(1,
-            'docker login',
-            ['-u', 'hello', '-p', 'world', 'https://123456789012.dkr.ecr.aws-region-1.amazonaws.com'],
+            'docker',
+            ['login', '-u', 'hello', '-p', 'world', 'https://123456789012.dkr.ecr.aws-region-1.amazonaws.com'],
             expect.anything());
         expect(core.saveState).toHaveBeenCalledTimes(0);
     });


### PR DESCRIPTION
We use the `exec` action helper to run our docker login command. The
`exec` function has the following signature:

```
 * @param     commandLine        command
 * @param     args               optional arguments
 * @param     options            optional exec options
```

Right now we specify some arguments as part of the `commandLine` (`login`)
while we pass the other arguments (e.g. username) as part of the `args`
array.

This commit now passes all arguments as an array.

This matches the signature of [`spawn`][1] and clarifies that this will
not be executed as a shellcommand and rather directly without the
involvement of a shell. This is critical because we don't need to think
about escaping special characters that might exist in the username and
password (only for windows the exec helper actually has to run this
through a `cmd` and does a hard job to properly escape everything)
 
[1]: https://github.com/actions/toolkit/blob/daf8bb00606d37ee2431d9b1596b88513dcf9c59/packages/exec/src/toolrunner.ts#L443

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
