### PR TITLE
feat: mask output docker password

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,6 +133,7 @@ async function run() {
 
       // Output docker username and password
       const secretSuffix = replaceSpecialCharacters(registryUri);
+      core.setSecret(creds[1]);
       core.setOutput(`${OUTPUTS.dockerUsername}_${secretSuffix}`, creds[0]);
       core.setOutput(`${OUTPUTS.dockerPassword}_${secretSuffix}`, creds[1]);
 


### PR DESCRIPTION
Signed-off-by: zhiqinli@amazon.com <zhiqinli@amazon.com>

*Issue #, if available:*
Docker password will be printed as plaintext in action logs if user reference it from outputs.

*Description of changes:*
Mask `dockerPassword`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
