### PR TITLE
chore: Add semantic PR check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,3 +14,19 @@ jobs:
       run: |
         npm ci
         npm test
+
+  conventional-commits:
+    name: Semantic Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: validate
+        uses: actions/github-script@v6
+        with:
+          script: |
+            // See https://gist.github.com/marcojahn/482410b728c31b221b70ea6d2c433f0c#file-conventional-commit-regex-md
+            const regex = /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([\w\-\.]+\))?(!)?: ([\w ])+([\s\S]*)/g;
+            const pr = context.payload.pull_request;
+            const title = pr.title;
+            if (title.match(regex) == null) {
+              throw `PR title "${title}"" does not match conventional commits from https://www.conventionalcommits.org/en/v1.0.0/`
+            }


### PR DESCRIPTION
I noticed that Mergify is no longer automatically merging PRs, and it looks like it's stuck waiting for a successful "Semantic Pull Request" check.  That check used to run against this repo automatically, but it is no longer maintained and no longer runs:
https://github.com/zeke/semantic-pull-requests

This PR copies over a drop-in replacement for that Semantic Pull Request check from https://github.com/aws-actions/amazon-ecs-deploy-task-definition/ to get Mergify running again.

Example of a PR that failed this new Semantic Pull Request check:
https://github.com/aws-actions/amazon-ecs-deploy-task-definition/actions/runs/3154695214

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
