### PR TITLE
Fix Readme documentation for ecr-public IAM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ The following minimum permissions are required for pushing an image to an ECR Pu
         "ecr-public:PutImage",
         "ecr-public:UploadLayerPart"
       ],
-      "Resource": "arn:aws:ecr-public:us-east-1:123456789012:repository/my-ecr-public-repo"
+      "Resource": "arn:aws:ecr-public::123456789012:repository/my-ecr-public-repo"
     }
   ]
 }


### PR DESCRIPTION
*Description of changes:*

The example IAM policy for ecr-public is wrong, the [linked documentation](https://docs.aws.amazon.com/AmazonECR/latest/public/security_iam_service-with-iam.html) clearly states the IAM Resource **should not include region** in the ARN:

**incorrect(Readme):**

```
arn:aws:ecr-public:us-east-1:123456789012:repository/my-ecr-public-repo
```

this policy never matches the ARN of the repository

**correct(Documentation):**

```
arn:aws:ecr-public::123456789012:repository/my-ecr-public-repo
```

**Note:** notice the `::` after `ecr-public`, no region there

Doc screenshot:

<img width="816" alt="Screenshot 2022-12-20 at 11 16 50 PM" src="https://user-images.githubusercontent.com/219289/208820514-69314204-034c-457f-8830-afbe0a8c6dfc.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
