### PR TITLE
Fix TOC anchor link for Examples of Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Logs in the local Docker client to one or more Amazon ECR Private registries or 
 
 <!-- toc -->
 
-- [Example of Usage](#example-of-usage)
+- [Example of Usage](#examples-of-usage)
 - [Credentials and Region](#credentials-and-region)
 - [Permissions](#permissions)
 - [Troubleshooting](#troubleshooting)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Change TOC markdown link from `#example-of-usage` to `#examples-of-usage` to match header text

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
