### PR TITLE
Add support for HTTP(S) proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,31 @@ The following minimum permissions are required for pushing an image to an ECR Pu
 }
 ```
 
+## Self-Hosted Runners
+
+### Proxy Configuration
+
+If you run in self-hosted environments and in secured environments where you need to use a specific proxy you can set it in the action manually.
+
+Additionally this action will always consider an already configured proxy in the environment.
+
+Manually configured proxy:
+
+```yaml
+uses: aws-actions/amazon-ecr-logins@v1.6.0
+with:
+  http-proxy: "http://companydomain.com:3128"
+````
+
+Proxy configured via an environment variable:
+
+```shell
+# Your environment configuration
+HTTP_PROXY="http://companydomain.com:3128"
+```
+
+The action will read the underlying proxy configuration from the environment and you don't need to configure it in the action.
+
 ## Troubleshooting
 
 ### Configure credentials

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
       Options: [private, public]
     required: false
     default: private
+  http-proxy:
+    description: 'Proxy to use for the AWS SDK agent'
+    required: false
 outputs:
   registry:
     description: >-

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const core = require('@actions/core');
 const exec = require('@actions/exec');
 const aws = require('aws-sdk');
+const proxy = require('https-proxy-agent');
 
 const ECR_LOGIN_GITHUB_ACTION_USER_AGENT = 'amazon-ecr-login-for-github-actions';
 const ECR_PUBLIC_REGISTRY_URI = 'public.ecr.aws';
@@ -70,11 +71,32 @@ async function getEcrPublicAuthTokenWrapper(authTokenRequest) {
   };
 }
 
+function configureProxy(proxyServer) {
+  const proxyFromEnv = process.env.HTTP_PROXY || process.env.http_proxy;
+
+  if (proxyServer || proxyFromEnv) {
+    let proxyToSet = null;
+
+    if (proxyServer){
+      console.log(`Setting proxy from actions input: ${proxyServer}`);
+      proxyToSet = proxyServer;
+    } else {
+      console.log(`Setting proxy from environment: ${proxyFromEnv}`);
+      proxyToSet = proxyFromEnv;
+    }
+
+    aws.config.update({
+      httpOptions: { agent: proxy(proxyToSet) }
+    });
+  }
+}
+
 async function run() {
   // Get inputs
   const skipLogout = core.getInput(INPUTS.skipLogout, { required: false }).toLowerCase() === 'true';
   const registries = core.getInput(INPUTS.registries, { required: false });
   const registryType = core.getInput(INPUTS.registryType, { required: false }).toLowerCase() || REGISTRY_TYPES.private;
+  const proxyServer = core.getInput('http-proxy', { required: false });
 
   const registryUriState = [];
 
@@ -82,6 +104,9 @@ async function run() {
     if (registryType !== REGISTRY_TYPES.private && registryType !== REGISTRY_TYPES.public) {
       throw new Error(`Invalid input for '${INPUTS.registryType}', possible options are [${REGISTRY_TYPES.private}, ${REGISTRY_TYPES.public}]`);
     }
+
+    // Configures proxy
+    configureProxy(proxyServer);
 
     // Get the ECR/ECR Public authorization token(s)
     const authTokenRequest = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
-        "aws-sdk": "^2.1340.0"
+        "aws-sdk": "^2.1340.0",
+        "https-proxy-agent": "^5.0.1"
       },
       "devDependencies": {
         "@zeit/ncc": "^0.22.3",
@@ -1297,6 +1298,17 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1805,7 +1817,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2672,6 +2683,18 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -3913,8 +3936,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -5997,6 +6019,14 @@
       "dev": true,
       "requires": {}
     },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -6362,7 +6392,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -6996,6 +7025,15 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
     },
     "human-signals": {
       "version": "2.1.0",
@@ -7914,8 +7952,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",
-    "aws-sdk": "^2.1340.0"
+    "aws-sdk": "^2.1340.0",
+    "https-proxy-agent": "^5.0.1"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.22.3",


### PR DESCRIPTION
*Issue:* https://github.com/aws-actions/amazon-ecr-login/issues/416

*Description of changes:* Add the same AWS SDK proxy configuration handling to the action, as provided in https://github.com/aws-actions/configure-aws-credentials, using the same configuration parameters. Add unit tests based on modifications done in https://github.com/koke001-sme/amazon-ecr-login. Update the README to reflect the new configuration option.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
