### PR TITLE
Fix Readme typo and update Contributing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ reported the issue. Please try to include as much information as you can. Detail
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Additionally, this action will always consider an already configured proxy in th
 
 Proxy configured via action input:
 ```yaml
-uses: aws-actions/amazon-ecr-logins@v1.6.0
+uses: aws-actions/amazon-ecr-login@v1.6.0
 with:
   http-proxy: "http://companydomain.com:3128"
 ````


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fixed typo in README by changing `uses: aws-actions/amazon-ecr-logins@v1.6.0` to `uses: aws-actions/amazon-ecr-login@v1.6.0` in the Proxy Configuration section
- Updated Contributing PR instructions file to use _main_ branch as the source instead of the _master_ branch

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
