### PR TITLE
feat: provide input to optionally mask output docker password

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,28 @@ Logs in the local Docker client to one or more Amazon ECR Private registries or 
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 ```
 
+#### Login to Amazon ECR Private, then build and push a Docker image masking the password:
+
+> [!WARNING]
+> Setting mask-password to true will prevent the password GitHub output from being shared between separate jobs.
+
+```yaml
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: 'true'
+
+      - name: Build, tag, and push docker image to Amazon ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: my-ecr-repo
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+```
+
 #### Login to Amazon ECR Public, then build and push a Docker image:
 ```yaml
       - name: Login to Amazon ECR Public

--- a/action.yml
+++ b/action.yml
@@ -4,12 +4,29 @@ branding:
   icon: 'cloud'
   color: 'orange'
 inputs:
+  http-proxy:
+    description: >-
+      Proxy to use for the AWS SDK agent.
+    required: false
+  mask-password:
+    description: >-
+      Mask the docker password to prevent it being printed to logs to std-out. This will prevent the
+      password GitHub output from being shared between separate jobs.
+      Options: ['true', 'false']
+    required: false
+    default: 'false'
   registries:
     description: >-
       A comma-delimited list of AWS account IDs that are associated with the ECR Private registries.
       If you do not specify a registry, the default ECR Private registry is assumed.
       If 'public' is given as input to 'registry-type', this input is ignored.
     required: false
+  registry-type:
+    description: >-
+      Which ECR registry type to log into.
+      Options: [private, public]
+    required: false
+    default: private
   skip-logout:
     description: >-
       Whether to skip explicit logout of the registries during post-job cleanup.
@@ -18,16 +35,6 @@ inputs:
       Options: ['true', 'false']
     required: false
     default: 'false'
-  registry-type:
-    description: >-
-      Which ECR registry type to log into.
-      Options: [private, public]
-    required: false
-    default: private
-  http-proxy:
-    description: >-
-      Proxy to use for the AWS SDK agent.
-    required: false
 outputs:
   registry:
     description: >-

--- a/index.js
+++ b/index.js
@@ -9,10 +9,11 @@ const ECR_LOGIN_GITHUB_ACTION_USER_AGENT = 'amazon-ecr-login-for-github-actions'
 const ECR_PUBLIC_REGISTRY_URI = 'public.ecr.aws';
 
 const INPUTS = {
-  skipLogout: 'skip-logout',
+  httpProxy: 'http-proxy',
+  maskPassword: 'mask-password',
   registries: 'registries',
   registryType: 'registry-type',
-  httpProxy: 'http-proxy'
+  skipLogout: 'skip-logout'
 };
 
 const OUTPUTS = {
@@ -104,10 +105,11 @@ function replaceSpecialCharacters(registryUri) {
 
 async function run() {
   // Get inputs
-  const skipLogout = core.getInput(INPUTS.skipLogout, { required: false }).toLowerCase() === 'true';
+  const httpProxy = core.getInput(INPUTS.httpProxy, { required: false });
+  const maskPassword = core.getInput(INPUTS.maskPassword, { required: false }).toLowerCase() === 'true';
   const registries = core.getInput(INPUTS.registries, { required: false });
   const registryType = core.getInput(INPUTS.registryType, { required: false }).toLowerCase() || REGISTRY_TYPES.private;
-  const httpProxy = core.getInput(INPUTS.httpProxy, { required: false });
+  const skipLogout = core.getInput(INPUTS.skipLogout, { required: false }).toLowerCase() === 'true';
 
   const registryUriState = [];
 
@@ -169,6 +171,7 @@ async function run() {
 
       // Output docker username and password
       const secretSuffix = replaceSpecialCharacters(registryUri);
+      if (maskPassword) core.setSecret(creds[1]);
       core.setOutput(`${OUTPUTS.dockerUsername}_${secretSuffix}`, creds[0]);
       core.setOutput(`${OUTPUTS.dockerPassword}_${secretSuffix}`, creds[1]);
 


### PR DESCRIPTION
This will allow the user to specify an optional input to mask the Docker password from being leaked in workflow logs via either explicitly printing or running a job in debug mode. Since many users rely on the output, the default behaviour has been false to ensure this is not a breaking change.

This also re-arranges the inputs throughout the code and in the GH action spec to be in alphabetical order as a styling improvement.

Issue #

Closes #485 

*Description of changes:*

- Add new input 'mask-password', which will prevent the password from being logged to the console
- Add a test to cover `mask-password` case and update existing tests
- Re-order inputs in alphabetical order to improve styling
