### PR TITLE
docs: update contribution guide with reference to conventional commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ To send us a pull request, please:
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
 3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
+4. Commit to your fork using clear commit messages, and please follow guidelines from [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 


### PR DESCRIPTION
I ran into an issue with a PR I raised (https://github.com/aws-actions/amazon-ecr-login/pull/538), that failed CI because my commit message didn't follow the format in conventional commits.

This PR adds explicit text to the CONTRIBUTING section so others don't make the same mistake.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
