### PR TITLE
ci: Use PR workflow for packaging instead of direct push

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 name: Package
 
@@ -23,9 +24,15 @@ jobs:
         npm ci
         npm test
         npm run package
-    - name: Commit
+    - name: Create PR
       run: |
         git config --global user.name "GitHub Actions"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        BRANCH="automated-packaging/update-dist"
+        git checkout -b "$BRANCH"
         git add dist/
-        git commit -m "chore: Update dist" || echo "No changes to commit"
-        git push origin HEAD:main
+        git commit -m "chore: Update dist" || exit 0
+        git push --force origin "$BRANCH"
+        gh pr create --title "chore: Update dist" --body "Automated packaging update" --base main --head "$BRANCH" || echo "PR already exists"
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,8 +1,7 @@
 queue_rules:
   - name: default
     merge_method: squash
-    conditions:
-      # Conditions to get out of the queue (= merged)
+    merge_conditions:
       - status-success=Run Unit Tests
 
 pull_request_rules:
@@ -19,6 +18,7 @@ pull_request_rules:
       - -merged
       - -closed
       - author!=dependabot[bot]
+      - author!=github-actions[bot]
     actions:
       queue:
         name: default
@@ -30,6 +30,22 @@ pull_request_rules:
       - status-success=Run Unit Tests
       - status-success=Semantic Pull Request
       - -title~=(WIP|wip)
+      - -label~=(blocked|do-not-merge)
+      - -merged
+      - -closed
+    actions:
+      review:
+        type: APPROVE
+      queue:
+        name: default
+
+  - name: Automatically approve and merge packaging PRs
+    conditions:
+      - base=main
+      - author=github-actions[bot]
+      - head=automated-packaging/update-dist
+      - status-success=Run Unit Tests
+      - status-success=Semantic Pull Request
       - -label~=(blocked|do-not-merge)
       - -merged
       - -closed


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

The `package.yml` workflow previously pushed directly to `main`, which fails on protected branches. This change:

- Replaces the direct push with a `gh` CLI PR workflow that creates a PR from a dedicated `automated-packaging/update-dist` branch
- Adds `pull-requests: write` permission to the workflow
- Adds a mergify rule to auto-approve and merge packaging PRs from `github-actions[bot]`, matching the existing pattern for dependabot PRs
- Excludes `github-actions[bot]` from the general merge rule so packaging PRs only go through their dedicated auto-merge rule
- Renames the deprecated `conditions` field to `merge_conditions` in `queue_rules`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.