### PR TITLE
ci: Remove status check requirements for packaging PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -44,8 +44,6 @@ pull_request_rules:
       - base=main
       - author=github-actions[bot]
       - head=automated-packaging/update-dist
-      - status-success=Run Unit Tests
-      - status-success=Semantic Pull Request
       - -label~=(blocked|do-not-merge)
       - -merged
       - -closed


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Removes status check requirements from the packaging PR mergify rule. The packaging workflow already runs tests before creating the PR, so requiring status checks on the PR itself is redundant. Additionally, PRs created with `GITHUB_TOKEN` do not trigger `pull_request` workflows, making the checks impossible to satisfy without workarounds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.