### PR TITLE
fix: prefer explicit env var credentials over Pod Identity

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,12 @@ function configureProxy(httpProxy) {
 }
 
 function getCredentials() {
+  // If explicit credentials are set (e.g. by configure-aws-credentials), let the default chain use them
+  if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
+    core.info("Using environment variable credentials.");
+    return undefined;
+  }
+
   // If running in a Pod Identity environment (EKS Pod Identity)
   if (process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI) {
     core.info("Using Pod Identity credentials via fromHttp()");

--- a/index.test.js
+++ b/index.test.js
@@ -669,6 +669,28 @@ describe('Pod Identity Support', () => {
     );
   });
 
+  test('prefers explicit env var credentials over Pod Identity', async () => {
+    process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI = TEST_CONSTANTS.POD_IDENTITY_URI;
+    process.env.AWS_ACCESS_KEY_ID = 'mock-access-key-id';
+    process.env.AWS_SECRET_ACCESS_KEY = 'mock-secret-access-key';
+    process.env.AWS_SESSION_TOKEN = 'mock-session-token';
+    ecrMock.on(GetAuthorizationTokenCommand).resolves({
+      authorizationData: [{
+        authorizationToken: Buffer.from('AWS:token').toString('base64'),
+        proxyEndpoint: TEST_CONSTANTS.REGISTRY_ENDPOINT
+      }]
+    });
+
+    await run();
+
+    expect(process.env.AWS_SDK_LOAD_CONFIG).toBeUndefined();
+    expect(exec.exec).toHaveBeenCalledWith(
+      'docker',
+      ['login', '-u', 'AWS', '-p', 'token', TEST_CONSTANTS.REGISTRY_ENDPOINT],
+      expect.anything()
+    );
+  });
+
   test('handles error when Pod Identity credentials are invalid', async () => {
     process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI = TEST_CONSTANTS.POD_IDENTITY_URI;
     ecrMock.on(GetAuthorizationTokenCommand).rejects(new Error('Invalid credentials'));


### PR DESCRIPTION
*Issue #, if available:* #952

*Description of changes:* `getCredentials()` now checks for explicit `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` environment variables before falling back to Pod Identity's `fromHttp()`. This preserves Pod Identity support while respecting credentials set by configure-aws-credentials.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
