### PR TITLE
fix: use realpathSync for main module check

### DIFF
--- a/cleanup.js
+++ b/cleanup.js
@@ -1,5 +1,6 @@
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
+import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 /**
@@ -57,6 +58,6 @@ async function cleanup() {
 export default cleanup;
 
 /* istanbul ignore next */
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if (realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url))) {
   cleanup();
 }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ import { NodeHttpHandler } from '@aws-sdk/node-http-handler';
 import { fromHttp } from '@aws-sdk/credential-providers';
 import { ECRClient, GetAuthorizationTokenCommand } from '@aws-sdk/client-ecr';
 import { ECRPUBLICClient, GetAuthorizationTokenCommand as GetAuthorizationTokenCommandPublic } from '@aws-sdk/client-ecr-public';
+import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 const ECR_LOGIN_GITHUB_ACTION_USER_AGENT = 'amazon-ecr-login-for-github-actions';
@@ -226,6 +227,6 @@ export {
 };
 
 /* istanbul ignore next */
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if (realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url))) {
   run();
 }


### PR DESCRIPTION
*Description of changes:* Since v2.0.2 the action does not work anymore for Gitea. #889 (0edf37c874c498febf26b741a3cf9f75f967cc4c) made changes to the check if the module was run as the main module, because it upgraded to ES Modules. The check does work for Github runners but not for Gitea. This is because Gitea works with symlinks. It could also be the case that some other custom runners have the same issue. This PR fixes this by adding realpath lookups.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.