### PR TITLE
docs: Populate changelog and include dependency updates in future releases

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,0 +1,15 @@
+{
+  "types": [
+    {"type": "feat", "section": "Features"},
+    {"type": "fix", "section": "Bug Fixes"},
+    {"type": "chore", "scope": "deps", "section": "Dependency Updates"},
+    {"type": "chore", "scope": "deps-dev", "hidden": true},
+    {"type": "chore", "hidden": true},
+    {"type": "docs", "hidden": true},
+    {"type": "style", "hidden": true},
+    {"type": "refactor", "hidden": true},
+    {"type": "perf", "section": "Performance Improvements"},
+    {"type": "test", "hidden": true},
+    {"type": "ci", "hidden": true}
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,41 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### [2.1.5](https://github.com/aws-actions/amazon-ecr-login/compare/v2.1.4...v2.1.5) (2026-05-06)
 
+
+### Dependency Updates
+
+* bump @aws-sdk/client-ecr from 3.1038.0 to 3.1043.0 ([#1040](https://github.com/aws-actions/amazon-ecr-login/issues/1040))
+* bump @aws-sdk/client-ecr-public from 3.1034.0 to 3.1043.0 ([#1032](https://github.com/aws-actions/amazon-ecr-login/issues/1032), [#1041](https://github.com/aws-actions/amazon-ecr-login/issues/1041))
+* bump @aws-sdk/credential-providers ([#1030](https://github.com/aws-actions/amazon-ecr-login/issues/1030), [#1043](https://github.com/aws-actions/amazon-ecr-login/issues/1043))
+
 ### [2.1.4](https://github.com/aws-actions/amazon-ecr-login/compare/v2.1.3...v2.1.4) (2026-04-22)
+
+
+### Dependency Updates
+
+* bump @actions/core from 3.0.0 to 3.0.1 ([#1015](https://github.com/aws-actions/amazon-ecr-login/issues/1015))
+* bump @aws-sdk/client-ecr from 3.1030.0 to 3.1034.0 ([#1017](https://github.com/aws-actions/amazon-ecr-login/issues/1017))
+* bump @aws-sdk/client-ecr-public from 3.1026.0 to 3.1034.0 ([#1016](https://github.com/aws-actions/amazon-ecr-login/issues/1016))
+* bump @aws-sdk/credential-providers ([#1014](https://github.com/aws-actions/amazon-ecr-login/issues/1014))
 
 ### [2.1.3](https://github.com/aws-actions/amazon-ecr-login/compare/v2.1.2...v2.1.3) (2026-04-15)
 
+
+### Dependency Updates
+
+* bump @aws-sdk/client-ecr from 3.1021.0 to 3.1030.0 ([#987](https://github.com/aws-actions/amazon-ecr-login/issues/987), [#1001](https://github.com/aws-actions/amazon-ecr-login/issues/1001))
+* bump @aws-sdk/client-ecr-public from 3.1021.0 to 3.1026.0 ([#990](https://github.com/aws-actions/amazon-ecr-login/issues/990))
+* bump @aws-sdk/credential-providers ([#1002](https://github.com/aws-actions/amazon-ecr-login/issues/1002))
+* bump https-proxy-agent from 8.0.0 to 9.0.0 ([#991](https://github.com/aws-actions/amazon-ecr-login/issues/991))
+
 ### [2.1.2](https://github.com/aws-actions/amazon-ecr-login/compare/v2.1.1...v2.1.2) (2026-04-01)
+
+
+### Dependency Updates
+
+* bump @aws-sdk/client-ecr from 3.1011.0 to 3.1021.0 ([#966](https://github.com/aws-actions/amazon-ecr-login/issues/966), [#977](https://github.com/aws-actions/amazon-ecr-login/issues/977))
+* bump @aws-sdk/client-ecr-public from 3.1011.0 to 3.1021.0 ([#963](https://github.com/aws-actions/amazon-ecr-login/issues/963), [#976](https://github.com/aws-actions/amazon-ecr-login/issues/976))
+* bump @aws-sdk/credential-providers ([#965](https://github.com/aws-actions/amazon-ecr-login/issues/965), [#978](https://github.com/aws-actions/amazon-ecr-login/issues/978))
 
 ### [2.1.1](https://github.com/aws-actions/amazon-ecr-login/compare/v2.1.0...v2.1.1) (2026-03-24)
 


### PR DESCRIPTION
## Summary

Addresses #1029 — the changelog was not being populated for releases that only contained dependency updates.

## Changes

1. **Backfill changelog entries** for releases 2.1.2–2.1.5 with their dependency updates
2. **Add `.versionrc.json`** to configure conventional-changelog to include `chore(deps):` commits under a "Dependency Updates" section in future releases

## Root Cause

The release automation uses standard-version/conventional-changelog, which by default only includes `feat:` and `fix:` commits. Releases 2.1.2–2.1.5 only contained `chore(deps):` commits (Dependabot bumps), so the changelog entries were empty.

## Testing

- [x] Existing tests pass
- The `.versionrc.json` will take effect on the next release

Closes #1029