### PR TITLE
docs: fix contributing license link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,6 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/aws-actions/amazon-ecr-login/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.


### PR DESCRIPTION
*Issue #, if available:*

None — this is a one-line broken-link correction found by comparing the contribution guide with the repository's actual branches.

*Description of changes:*

`CONTRIBUTING.md` links the project license through the removed `master` branch:

```markdown
https://github.com/aws-actions/amazon-ecr-login/blob/master/LICENSE
```

The repository's default branch is `main`, the `master` ref does not exist, and `LICENSE` exists at the repository root on `main`. The current link therefore leads contributors to a missing page.

Replace it with the branch-independent relative link:

```markdown
[LICENSE](LICENSE)
```

A relative link also remains correct in forks and across any future default-branch rename.

Validation:

- default branch: `main`
- `GET /git/ref/heads/master`: not found
- `GET /contents/LICENSE?ref=main`: found
- Markdown target `LICENSE` exists beside `CONTRIBUTING.md`
- `git diff --check`: clean

Documentation only; no product code or test behavior changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
